### PR TITLE
Implement rule close timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Temporary allow access to your cloud infrastructure by authenticating at the gat
 ### Environments
 | Provider   | Supported status | Required Environment Variables |
 |---	|---	|---    |
-| Vultr | Partially supported, no port-ranges and the white list lasts for a hardcoded amount of 120 seconds |`VULTR_API_KEY`, `VULTR_FIREWALL_GROUP_ID`|
+| Vultr | Partially supported, no configurable port or port-ranges |`VULTR_API_KEY`, `VULTR_FIREWALL_GROUP_ID`|
 | Digitalocean | In development | None yet |
 
 ## Getting Started

--- a/application/application.go
+++ b/application/application.go
@@ -39,7 +39,7 @@ func (app *Application) mux() *gorilla_mux.Router {
 	adapterFactory := adapters.NewAdapterFactory(app.config)
 	handler := handlers.NewGateHandler(
 		adapterFactory.GetAdapter(),
-		app.config.GetInt("closure_timeout"),
+		app.config.GetInt("rule_close_timeout"),
 	)
 
 	router.Handle("/", http.HandlerFunc(handler.PostOpen)).Methods("POST")

--- a/handlers/gate.go
+++ b/handlers/gate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nstapelbroek/gatekeeper/adapters"
 	"github.com/nstapelbroek/gatekeeper/domain/firewall"
 	"github.com/nstapelbroek/gatekeeper/middlewares"
+	"fmt"
 )
 
 type gateHandler struct {
@@ -47,12 +48,12 @@ func (handler gateHandler) PostOpen(res http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	timer := time.NewTimer(time.Second * 120)
+	timer := time.NewTimer(time.Duration(handler.timeout))
 	go func() {
 		<-timer.C
 		handler.adapter.DeleteRule(rule)
 	}()
 
 	res.WriteHeader(http.StatusCreated)
-	res.Write([]byte(origin.String() + " has been whitelisted for 120 seconds"))
+	res.Write([]byte(fmt.Sprintf("%s has been whitelisted for %d seconds", origin.String(), handler.timeout)))
 }

--- a/handlers/gate_test.go
+++ b/handlers/gate_test.go
@@ -26,7 +26,7 @@ func prepareRequest(t *testing.T) *http.Request {
 func TestGateOpenHandler(t *testing.T) {
 	req := prepareRequest(t)
 	adapterInstance := dummy.NewDummyAdapter()
-	gateHandler := NewGateHandler(adapterInstance, 1)
+	gateHandler := NewGateHandler(adapterInstance, 2)
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(gateHandler.PostOpen)
@@ -36,7 +36,7 @@ func TestGateOpenHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
 	}
 
-	expected := `127.0.0.1 has been whitelisted for 120 seconds`
+	expected := `127.0.0.1 has been whitelisted for 2 seconds`
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected)
 	}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func newConfig() (*viper.Viper, error) {
 	c.SetDefault("http_auth_password", "password")
 	c.SetDefault("resolve_type", "RemoteAddr")
 	c.SetDefault("resolve_header", "X-Forwarded-For")
-	c.SetDefault("closure_timeout", 300)
+	c.SetDefault("rule_close_timeout", 120)
 
 	c.AutomaticEnv()
 


### PR DESCRIPTION
### What has been done:
- Changed an configuration key name to create a distinction in rule configurations
- Implemented the `rule_close_timeout` value as the timer value before calling the `deleterule` allowing users to configure how long a rule will be kept in place. Defaults to 120 seconds
 